### PR TITLE
Fix for attributes appending in multiple file assets

### DIFF
--- a/applications/helpers/assets_helper.php
+++ b/applications/helpers/assets_helper.php
@@ -35,10 +35,10 @@ if (!function_exists('_process_array'))
           {
             if(is_array($child_1_value))
             {
-              $attr .= ' ';
+              $attr = ' ';
               foreach($child_1_value as $child_2_key => $child_2_value)
               {
-                $attr .= $child_2_key.'="'.$child_2_value.'"';
+                $attr .= $child_2_key.'="'.$child_2_value.'" ';
               }
             }
             else


### PR DESCRIPTION
All the attributes of one asset were appending to the next asset and goes on till the last file, and fixed the spacing between attributes when declaring multiple attributes for the same asset